### PR TITLE
chore: release on workflow_dispatch

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.201
+          dotnet-version: 3.1.x
       # build src
       - run: dotnet build -c Debug ./src/DFrame
       - run: dotnet build -c Debug ./src/DFrame.Kubernetes

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -7,9 +7,8 @@ on:
     tags:
       - "!*" # not a tag push
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches:
+      - master
 
 jobs:
   build-dotnet:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,13 +12,14 @@ on:
         default: "false"
 
 env:
+  GIT_TAG: ${{ github.event.inputs.tag }}
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
   DOTNET_SDK_VERISON_3: 3.1.x
 
 jobs:
   build-dotnet:
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -40,7 +41,6 @@ jobs:
     needs: [build-dotnet]
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -49,14 +49,26 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
+      # tag
+      - uses: actions/checkout@v2
+      - name: tag
+        run: git tag ${{ env.GIT_TAG }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
       # Create Releases
       - uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Ver.${{ github.ref }}
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: Ver.${{ env.GIT_TAG }}
+          draft: true
+          prerelease: false
       # Download (All) Artifacts to current directory
       - uses: actions/download-artifact@v2
       # Upload to NuGet

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,11 +27,9 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
-      # build and test
+      # pack nuget
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
       # - run: dotnet test -c Release --no-build
-
-      # pack packages
       - run: dotnet pack ./src/DFrame/DFrame.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
       - run: dotnet pack ./src/DFrame.LoadTesting/DFrame.LoadTesting.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
       - run: dotnet pack ./src/DFrame.OutOfProcess/DFrame.OutOfProcess.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,6 +35,10 @@ jobs:
       - run: dotnet pack ./src/DFrame.LoadTesting/DFrame.LoadTesting.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
       - run: dotnet pack ./src/DFrame.OutOfProcess/DFrame.OutOfProcess.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
       - run: dotnet pack ./src/DFrame.Kubernetes/DFrame.Kubernetes.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nuget
+          path: ./publish
 
   create-release:
     if: github.event.inputs.dry_run == 'false'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,14 +1,24 @@
 name: Build-Release
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag: git tag you want create. (sample 1.0.0)"
+        required: true
+      dry_run:
+        description: "dry_run: true will never create release/nuget."
+        required: true
+        default: "false"
+
+env:
+  DOTNET_SDK_VERISON_3: 3.1.x
 
 jobs:
   build-dotnet:
     runs-on: ubuntu-latest
     env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -16,22 +26,40 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.201
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
+          dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
       # build and test
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
       # - run: dotnet test -c Release --no-build
 
       # pack packages
-      - run: dotnet pack ./src/DFrame/DFrame.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }}
-      - run: dotnet pack ./src/DFrame.LoadTesting/DFrame.LoadTesting.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }}
-      - run: dotnet pack ./src/DFrame.OutOfProcess/DFrame.OutOfProcess.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }}
-      - run: dotnet pack ./src/DFrame.Kubernetes/DFrame.Kubernetes.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }}
+      - run: dotnet pack ./src/DFrame/DFrame.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
+      - run: dotnet pack ./src/DFrame.LoadTesting/DFrame.LoadTesting.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
+      - run: dotnet pack ./src/DFrame.OutOfProcess/DFrame.OutOfProcess.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
+      - run: dotnet pack ./src/DFrame.Kubernetes/DFrame.Kubernetes.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
 
+  create-release:
+    if: github.event.inputs.dry_run == 'false'
+    needs: [build-dotnet]
+    runs-on: ubuntu-latest
+    env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      NUGET_XMLDOC_MODE: skip
+    steps:
+      # setup dotnet for nuget push
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
+      # Create Releases
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Ver.${{ github.ref }}
+      # Download (All) Artifacts to current directory
+      - uses: actions/download-artifact@v2
       # Upload to NuGet
-      - run: dotnet nuget push "./src/DFrame/bin/Release/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-      - run: dotnet nuget push "./src/DFrame.LoadTesting/bin/Release/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-      - run: dotnet nuget push "./src/DFrame.OutOfProcess/bin/Release/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-      - run: dotnet nuget push "./src/DFrame.Kubernetes/bin/Release/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
+      - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}


### PR DESCRIPTION
## TL;DR

Change release flow from `tag push` to `worlkflow dispatch`.
This enable `dry_run` to create package before tag/release.

## Change

* before: tag version `1.0.0` and push to origin will start release github actions.
* after: go to github actions -> build-release -> Workflow dispatch -> set `tag` & `dry_run`.
