### PR TITLE
feature: Support Kubernetes NodeSelector

### DIFF
--- a/src/DFrame.Kubernetes/Internals/EnvironmentVariablesProvider.cs
+++ b/src/DFrame.Kubernetes/Internals/EnvironmentVariablesProvider.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections;
+
+namespace DFrame.Kubernetes.Internals
+{
+    internal class EnvironmentVariablesProvider
+    {
+        public IDictionary<string, string> Data { get; private set; }
+
+        private readonly string _prefix;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public EnvironmentVariablesProvider() : this(string.Empty)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance with the specified prefix.
+        /// </summary>
+        /// <param name="prefix">A prefix used to filter the environment variables.</param>
+        public EnvironmentVariablesProvider(string prefix)
+        {
+            _prefix = prefix ?? string.Empty;
+            Load();
+        }
+
+        /// <summary>
+        /// Load Current Environment Variables.
+        /// </summary>
+        public void Load()
+        {
+            Load(Environment.GetEnvironmentVariables());
+        }
+
+        private void Load(IDictionary envVariables)
+        {
+            Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var filteredEnvVariables = envVariables
+                .Cast<DictionaryEntry>()
+                .Select(x =>
+                {
+                    var key = (string)x.Key;
+                    x.Key = NormalizeKey(key);
+                    return x;
+                })
+                .Where(entry => ((string)entry.Key).StartsWith(_prefix, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var envVariable in filteredEnvVariables)
+            {
+                var key = ((string)envVariable.Key).Substring(_prefix.Length);
+                Data[key] = (string)envVariable.Value;
+            }
+        }
+
+        private static string NormalizeKey(string key)
+        {
+            // replace FOO__BAR to FOO:BAR
+            return key.Replace("__", ":");
+        }
+    }
+
+    /// <summary>
+    /// Offer EnvironmentVariables Source with specific Data type.
+    /// </summary>
+    /// Usage Samples.....
+    /// // pattern 1. use prefix.
+    /// var provider = new EnvironmentVariablesProvider("DFRAME_WORKER_");
+    /// provider.Dump();
+    /// var source1 = new EnvironmentVariablesSource("DFRAME_WORKER_");
+    /// source1.GetNodeSelectors("NODESELECTOR").Dump("pattern 1.");
+    /// 
+    /// // pattern 2. use full env key.
+    /// var source2 = new EnvironmentVariablesSource(string.Empty);
+    /// source2.GetNodeSelectors("DFRAME_WORKER_NODESELECTOR").Dump("pattern 2.");
+    internal class EnvironmentVariablesSource
+    {
+        private IDictionary<string, string> _data;
+
+        public EnvironmentVariablesSource(string prefix)
+        {
+            var provider = new EnvironmentVariablesProvider(prefix);
+            _data = provider.Data;
+        }
+
+        /// <summary>
+        /// Get Kubernetse NodeSelector from Environment Variables.
+        /// env sample: `DFRAME_WORKER_NODESELECTOR__0__KEY = VALUE` will become `KEY = VALUE` entries.
+        /// </summary>
+        /// <param name="prefix"></param>
+        /// <returns></returns>
+        public IDictionary<string, string> GetNodeSelectors(string prefix)
+        {
+            // pick up `DFRAME_WORKER_NODESELECTOR*` entries
+            var nodeSelectors = _data
+                .Where(x => x.Key.StartsWith(prefix))
+                .Select((x, i) =>
+                {
+                    // DFRAME_WORKER_NODESELECTOR:0:KEY -> KEY
+                    var key = x.Key
+                        .Substring(prefix.Length) // DFRAME_WORKER_NODESELECTOR:0:KEY -> :0:KEY
+                        .Substring($":{i}:".Length); // :0:KEY -> KEY
+                    return (key, x.Value);
+                })
+                .ToDictionary(kv => kv.key, kv => kv.Value);
+
+            return nodeSelectors;
+        }
+    }
+}

--- a/src/DFrame.Kubernetes/Kubernetes.Deployment.cs
+++ b/src/DFrame.Kubernetes/Kubernetes.Deployment.cs
@@ -53,6 +53,8 @@ namespace DFrame.Kubernetes
         ///               memory: 1000Mi
         ///       imagePullSecrets:
         ///         - name: {imagePullSecret}
+        ///       nodeSelector:
+        ///         eks.amazonaws.com/capacityType: SPOT
         /// </remarks>
         /// <param name="name"></param>
         /// <param name="image"></param>
@@ -62,8 +64,18 @@ namespace DFrame.Kubernetes
         /// <param name="imagePullPolicy"></param>
         /// <param name="imagePullSecret"></param>
         /// <param name="replicas"></param>
+        /// <param name="nodeSelector"></param>
         /// <returns></returns>
-        public V1Deployment CreateDeploymentDefinition(string name, string image, string imageTag, string host, int port, string imagePullPolicy = "IfNotPresent", string imagePullSecret = "", int replicas = 1)
+        public V1Deployment CreateDeploymentDefinition(
+            string name, 
+            string image, 
+            string imageTag, 
+            string host, 
+            int port, 
+            string imagePullPolicy = "IfNotPresent", 
+            string imagePullSecret = "", 
+            int replicas = 1, 
+            IDictionary<string, string> nodeSelector = null)
         {
             var labels = new Dictionary<string, string>
             {
@@ -145,6 +157,11 @@ namespace DFrame.Kubernetes
                     },
                 };
             }
+            if (nodeSelector != null && nodeSelector.Count != 0)
+            {
+                definition.Spec.Template.Spec.NodeSelector = nodeSelector;
+            }
+
             return definition;
         }
 

--- a/src/DFrame.Kubernetes/Kubernetes.Job.cs
+++ b/src/DFrame.Kubernetes/Kubernetes.Job.cs
@@ -64,8 +64,18 @@ namespace DFrame.Kubernetes
         /// <param name="imagePullPolicy"></param>
         /// <param name="imagePullSecret"></param>
         /// <param name="parallelism"></param>
+        /// <param name="nodeSelector"></param>
         /// <returns></returns>
-        public V1Job CreateJobDefinition(string name, string image, string imageTag, string host, int port, string imagePullPolicy = "IfNotPresent", string imagePullSecret = "", int parallelism = 1)
+        public V1Job CreateJobDefinition(
+            string name, 
+            string image, 
+            string imageTag, 
+            string host, 
+            int port, 
+            string imagePullPolicy = "IfNotPresent", 
+            string imagePullSecret = "", 
+            int parallelism = 1,
+            IDictionary<string, string> nodeSelector = null)
         {
             var labels = new Dictionary<string, string>
             {
@@ -147,6 +157,10 @@ namespace DFrame.Kubernetes
                         Name = imagePullSecret,
                     },
                 };
+            }
+            if (nodeSelector != null && nodeSelector.Count != 0)
+            {
+                definition.Spec.Template.Spec.NodeSelector = nodeSelector;
             }
             return definition;
         }

--- a/src/DFrame.Kubernetes/KubernetesScalingProvider.cs
+++ b/src/DFrame.Kubernetes/KubernetesScalingProvider.cs
@@ -47,11 +47,9 @@ namespace DFrame.Kubernetes
         public string ImagePullPolicy { get; set; } = Environment.GetEnvironmentVariable("DFRAME_WORKER_IMAGE_PULL_POLICY") ?? "IfNotPresent";
         /// <summary>
         /// NodeSelector for Worker Kubernetes Pod.
-        /// If setting from EnvironmentVariables, use following.
-        /// DFRAME_WORKER_NODESELECTOR__0__KEY: VAL
-        /// DFRAME_WORKER_NODESELECTOR__1__KEY: VAL
+        /// Environment Variables sample: DFRAME_WORKER_NODESELECTOR='KEY1=FOO;KEY2=BAR'
         /// </summary>
-        public IDictionary<string, string> NodeSelector { get; set; } = new EnvironmentVariablesSource(string.Empty).GetNodeSelectors(prefix: "DFRAME_WORKER_NODESELECTOR");
+        public IDictionary<string, string> NodeSelector { get; set; } = new EnvironmentVariablesSource(string.Empty).GetNodeSelectors("DFRAME_WORKER_NODESELECTOR");
         /// <summary>
         /// Wait worker pod creationg timeout seconds. default 120 sec.
         /// </summary>

--- a/src/DFrame.Kubernetes/KubernetesScalingProvider.cs
+++ b/src/DFrame.Kubernetes/KubernetesScalingProvider.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DFrame.Kubernetes.Exceptions;
+using DFrame.Kubernetes.Internals;
 using DFrame.Kubernetes.Models;
 
 namespace DFrame.Kubernetes
@@ -29,31 +30,38 @@ namespace DFrame.Kubernetes
         /// </summary>
         public string Name { get; set; } = Environment.GetEnvironmentVariable("DFRAME_WORKER_NAME") ?? "dframe-worker";
         /// <summary>
-        /// Image Tag for Worker Kubernetes Image.
+        /// Image Tag for Worker Kubernetes pod.
         /// </summary>
         public string Image { get; set; } = Environment.GetEnvironmentVariable("DFRAME_WORKER_IMAGE_NAME") ?? "";
         /// <summary>
-        /// Image Tag for Worker Kubernetes Image.
+        /// Image Tag for Worker Kubernetes pod.
         /// </summary>
         public string ImageTag { get; set; } = Environment.GetEnvironmentVariable("DFRAME_WORKER_IMAGE_TAG") ?? "";
         /// <summary>
-        /// Image PullSecret for Worker Kubernetes Image. default empty.
+        /// Image PullSecret for Worker Kubernetes pod. default empty.
         /// </summary>
         public string ImagePullSecret { get; set; } = Environment.GetEnvironmentVariable("DFRAME_WORKER_IMAGE_PULL_SECERT") ?? "";
         /// <summary>
-        /// Image PullPolicy for Worker Kubernetes Image. default IfNotPresent.
+        /// Image PullPolicy for Worker Kubernetes pod. default IfNotPresent.
         /// </summary>
         public string ImagePullPolicy { get; set; } = Environment.GetEnvironmentVariable("DFRAME_WORKER_IMAGE_PULL_POLICY") ?? "IfNotPresent";
+        /// <summary>
+        /// NodeSelector for Worker Kubernetes Pod.
+        /// If setting from EnvironmentVariables, use following.
+        /// DFRAME_WORKER_NODESELECTOR__0__KEY: VAL
+        /// DFRAME_WORKER_NODESELECTOR__1__KEY: VAL
+        /// </summary>
+        public IDictionary<string, string> NodeSelector { get; set; } = new EnvironmentVariablesSource(string.Empty).GetNodeSelectors(prefix: "DFRAME_WORKER_NODESELECTOR");
         /// <summary>
         /// Wait worker pod creationg timeout seconds. default 120 sec.
         /// </summary>
         public int WorkerPodCreationTimeout { get; set; } = int.Parse(Environment.GetEnvironmentVariable("DFRAME_WORKER_POD_CREATE_TIMEOUT") ?? "120");
         /// <summary>
-        /// Cluster endpoint health check retry count
+        /// Cluster endpoint health check retry count.
         /// </summary>
         public int ClusterEndpointHealthRetry { get; set; } = int.Parse(Environment.GetEnvironmentVariable("DFRAME_CLUSTER_ENDPOINT_HEALTH_RETRY") ?? "60");
         /// <summary>
-        /// Cluster endpoint health check interval second
+        /// Cluster endpoint health check interval second.
         /// </summary>
         public int ClusterEndpointHealthInterval { get; set; } = int.Parse(Environment.GetEnvironmentVariable("DFRAME_CLUSTER_ENDPOINT_HEALTH_INTERVAL_SEC") ?? "10");
         /// <summary>
@@ -79,18 +87,24 @@ namespace DFrame.Kubernetes
 
         public KubernetesScalingProvider()
         {
+            _env = new KubernetesEnvironment();
             _operations = new Kubernetes(new KubernetesApiConfig
             {
                 ResponseHeaderType = HeaderContentType.Json,
                 SkipCertificateValidation = true,
             });
-            _env = new KubernetesEnvironment();
             _ns = _operations.Namespace;
         }
 
-        public KubernetesScalingProvider(KubernetesEnvironment kubernetesEnvironment) : base()
+        public KubernetesScalingProvider(KubernetesEnvironment kubernetesEnvironment)
         {
             _env = kubernetesEnvironment;
+            _operations = new Kubernetes(new KubernetesApiConfig
+            {
+                ResponseHeaderType = HeaderContentType.Json,
+                SkipCertificateValidation = true,
+            });
+            _ns = _operations.Namespace;
         }
 
         public async Task StartWorkerAsync(DFrameOptions options, int workerCount, IServiceProvider provider, IFailSignal failSignal, CancellationToken cancellationToken)
@@ -99,7 +113,6 @@ namespace DFrame.Kubernetes
 
             Console.WriteLine($"Scale out workers {_env.ScalingType}. {_ns}/{_env.Name} ({workerCount} pods)");
 
-            // todo: Can be replace with SRV record on svc.
             // confirm kubernetes master can connect with cluster api.
             Console.WriteLine($"Checking cluster Endpoint health.");
             var healthy = await _operations.TryConnectClusterEndpointAsync(_env.ClusterEndpointHealthRetry, TimeSpan.FromSeconds(_env.ClusterEndpointHealthInterval), cancellationToken);


### PR DESCRIPTION
## tl;dr;

This PR will offer Kubernetes ScalingProvider to support NodeSelector.

Environment variables can be define line `DFRAME_WORKER_NODESELECTOR='KEY1=VALUE1;KEY2=VALUE2'`

YAML sample.

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: dframe-master
spec:
  template:
    metadata:
      labels:
        app: dframe-master
    spec:
      serviceAccountName: dframe-master
      containers:
        - name: dframe-master
          env:
            - name: DFRAME_WORKER_NODESELECTOR
              value: "kube/nodetype=app;disktype=ssd"
```