### PR TITLE
feat: add KubernetesScalingProvider Resources support

### DIFF
--- a/src/DFrame.Kubernetes/Internals/EnvironmentVariablesProvider.cs
+++ b/src/DFrame.Kubernetes/Internals/EnvironmentVariablesProvider.cs
@@ -84,7 +84,7 @@ namespace DFrame.Kubernetes.Internals
         {
             // pick up `DFRAME_WORKER_NODESELECTOR` entries
             var nodeSelectors = _data
-                .Where(x => string.Equals(x.Key,key, StringComparison.OrdinalIgnoreCase))
+                .Where(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase))
                 .SelectMany(x => x.Value.Split(';')) // ['KEY1=FOO', 'KEY2=BAR']
                 .Select(x =>
                 {
@@ -118,8 +118,9 @@ namespace DFrame.Kubernetes.Internals
                     var entry = x.Split('=');
                     if (entry.Length != 2)
                         return null;
-                    if (entry[0] != "cpu" && entry[0] != "memory")
+                    if (!entry[0].Equals("cpu", StringComparison.OrdinalIgnoreCase) && !entry[0].Equals("memory", StringComparison.OrdinalIgnoreCase))
                         return null;
+                    entry[0] = entry[0].ToLower();
                     return entry; // [KEY1, FOO], [KEY2, BAR]
                 })
                 .Where(x => x != null)
@@ -127,5 +128,5 @@ namespace DFrame.Kubernetes.Internals
 
             return resources;
         }
-   }
+    }
 }

--- a/src/DFrame.Kubernetes/Kubernetes.Job.cs
+++ b/src/DFrame.Kubernetes/Kubernetes.Job.cs
@@ -65,6 +65,8 @@ namespace DFrame.Kubernetes
         /// <param name="imagePullSecret"></param>
         /// <param name="parallelism"></param>
         /// <param name="nodeSelector"></param>
+        /// <param name="resourcesLimits"></param>
+        /// <param name="resourcesRequests"></param>
         /// <returns></returns>
         public V1Job CreateJobDefinition(
             string name, 
@@ -75,12 +77,45 @@ namespace DFrame.Kubernetes
             string imagePullPolicy = "IfNotPresent", 
             string imagePullSecret = "", 
             int parallelism = 1,
-            IDictionary<string, string> nodeSelector = null)
+            IDictionary<string, string> nodeSelector = null,
+            IDictionary<string, string> resourcesLimits = null,
+            IDictionary<string, string> resourcesRequests = null)
         {
+            // labels
             var labels = new Dictionary<string, string>
             {
                 { "app", name },
             };
+
+            // resources
+            var resources = new V1ResourceRequirements
+            {
+                Limits = new Dictionary<string, ResourceQuantity>
+                {
+                    { "cpu", new ResourceQuantity{ Value = "2000m" } },
+                    { "memory", new ResourceQuantity{ Value = "1000Mi" } },
+                },
+                Requests = new Dictionary<string, ResourceQuantity>
+                {
+                    { "cpu", new ResourceQuantity{ Value = "100m" } },
+                    { "memory", new ResourceQuantity{ Value = "100Mi" } },
+                }
+            };
+            if (resourcesLimits != null && resourcesLimits.Count != 0)
+            {
+                foreach (var item in resourcesLimits)
+                {
+                    resources.Limits[item.Key] = new ResourceQuantity { Value = item.Value };
+                }
+            }
+            if (resourcesRequests != null && resourcesRequests.Count != 0)
+            {
+                foreach (var item in resourcesRequests)
+                {
+                    resources.Requests[item.Key] = new ResourceQuantity { Value = item.Value };
+                }
+            }
+
             var definition = new V1Job
             {
                 ApiVersion = "batch/v1",
@@ -127,20 +162,7 @@ namespace DFrame.Kubernetes
                                             Value = port.ToString(),
                                         }
                                     },
-                                    Resources = new V1ResourceRequirements
-                                    {
-                                        // todo: should be configuable
-                                        Limits = new Dictionary<string, ResourceQuantity>
-                                        {
-                                            { "cpu", new ResourceQuantity{ Value = "2000m" } },
-                                            { "memory", new ResourceQuantity{ Value = "1000Mi" } },
-                                        },
-                                        Requests = new Dictionary<string, ResourceQuantity>
-                                        {
-                                            { "cpu", new ResourceQuantity{ Value = "100m" } },
-                                            { "memory", new ResourceQuantity{ Value = "100Mi" } },
-                                        }
-                                    },
+                                    Resources = resources,
                                 },
                             },
                         },
@@ -148,6 +170,7 @@ namespace DFrame.Kubernetes
                 }
             };
 
+            // additional configurations
             if (!string.IsNullOrEmpty(imagePullSecret))
             {
                 definition.Spec.Template.Spec.ImagePullSecrets = new[]

--- a/src/DFrame.Kubernetes/KubernetesScalingProvider.cs
+++ b/src/DFrame.Kubernetes/KubernetesScalingProvider.cs
@@ -51,6 +51,16 @@ namespace DFrame.Kubernetes
         /// </summary>
         public IDictionary<string, string> NodeSelector { get; set; } = new EnvironmentVariablesSource(string.Empty).GetNodeSelectors("DFRAME_WORKER_NODESELECTOR");
         /// <summary>
+        /// Resources.Limits for Worker Kubernetes Pod.
+        /// Environment Variables sample: DFRAME_WORKER_RESOURCES_LIMITS='cpu=2000m;memory=1000Mi'
+        /// </summary>
+        public IDictionary<string, string> ResourcesLimits { get; set; } = new EnvironmentVariablesSource(string.Empty).GetNodeSelectors("DFRAME_WORKER_RESOURCES_LIMITS");
+        /// <summary>
+        /// Resources.Requests for Worker Kubernetes Pod.
+        /// Environment Variables sample: DFRAME_WORKER_RESOURCES_REQUESTS='cpu=2000m;memory=1000Mi'
+        /// </summary>
+        public IDictionary<string, string> ResourcesRequests { get; set; } = new EnvironmentVariablesSource(string.Empty).GetNodeSelectors("DFRAME_WORKER_RESOURCES_REQUESTS");
+        /// <summary>
         /// Wait worker pod creationg timeout seconds. default 120 sec.
         /// </summary>
         public int WorkerPodCreationTimeout { get; set; } = int.Parse(Environment.GetEnvironmentVariable("DFRAME_WORKER_POD_CREATE_TIMEOUT") ?? "120");
@@ -180,7 +190,19 @@ namespace DFrame.Kubernetes
         /// <returns></returns>
         private async ValueTask ScaleoutJobAsync(int nodeCount, string connectToHost, int connectToPort, CancellationToken cancellationToken)
         {
-            var def = _operations.CreateJobDefinition(_env.Name, _env.Image, _env.ImageTag, connectToHost, connectToPort, _env.ImagePullPolicy, _env.ImagePullSecret, nodeCount, _env.NodeSelector);
+            var def = _operations.CreateJobDefinition(
+                _env.Name, 
+                _env.Image, 
+                _env.ImageTag, 
+                connectToHost, 
+                connectToPort, 
+                _env.ImagePullPolicy, 
+                _env.ImagePullSecret, 
+                nodeCount, 
+                _env.NodeSelector,
+                _env.ResourcesLimits,
+                _env.ResourcesRequests
+            );
 
             try
             {
@@ -247,7 +269,18 @@ namespace DFrame.Kubernetes
         /// <returns></returns>
         private async ValueTask ScaleoutDeploymentAsync(int nodeCount, string connectToHost, int connectToPort, CancellationToken cancellationToken)
         {
-            var def = _operations.CreateDeploymentDefinition(_env.Name, _env.Image, _env.ImageTag, connectToHost, connectToPort, _env.ImagePullPolicy, _env.ImagePullSecret, nodeCount, _env.NodeSelector);
+            var def = _operations.CreateDeploymentDefinition(
+                _env.Name, 
+                _env.Image, 
+                _env.ImageTag, 
+                connectToHost, 
+                connectToPort, 
+                _env.ImagePullPolicy, 
+                _env.ImagePullSecret, 
+                nodeCount, 
+                _env.NodeSelector,
+                _env.ResourcesLimits,
+                _env.ResourcesRequests);
             try
             {
                 // watch worker pod creation.


### PR DESCRIPTION
## tl;dr;

Currently DFrame worker's Kubernetes spec `container.resources.limits` and `container.resources.requests` are hard code and uncontrollable.

This PR enable user to define their demanded requests/limits .

## Usage Sample

Add `DFRAME_WORKER_RESOURCES_LIMITS` and `DFRAME_WORKER_RESOURCES_REQUESTS`.

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: dframe-master
spec:
  template:
    spec:
      serviceAccountName: dframe-master
      containers:
        - name: dframe-master
          env:
            - name: DFRAME_MASTER_CONNECT_TO_HOST
              value: "dframe-master.dframe-fargate.svc.cluster.local"
            - name: DFRAME_WORKER_IMAGE_NAME
              value: 431046970529.dkr.ecr.ap-northeast-1.amazonaws.com/dframe-k8s
            - name: DFRAME_WORKER_IMAGE_TAG
              value: "0.1.0"
            - name: DFRAME_WORKER_POD_CREATE_TIMEOUT
              value: "300"
            - name: DFRAME_WORKER_RESOURCES_LIMITS # <-- this entry!
              value: "cpu=1000m;memory=1000Mi"
            - name: DFRAME_WORKER_RESOURCES_REQUESTS # <-- this entry!
              value: "cpu=1000m;memory=1000Mi"
```