### PR TITLE
feat: Add CommandMode to Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ It can check on `...` drawer on each worker result.
 ```csharp
 public class WorkloadContext
 {
+    public CommandMode CommandMode { get; }
     public ExecutionId ExecutionId { get; }
     public WorkloadId WorkloadId { get; }
     public int WorkloadCount { get; }

--- a/src/DFrame.Controller/Controller/DFrameControllerExecutionEngine.cs
+++ b/src/DFrame.Controller/Controller/DFrameControllerExecutionEngine.cs
@@ -43,7 +43,7 @@ public class DFrameControllerExecutionEngine : INotifyStateChanged
         this.eventMessagePublisher = eventMessagePublisher;
     }
 
-    public bool StartWorkerFlow(string workloadName, int concurrency, long totalRequestCount, int workerLimit, KeyValuePair<string, string?>[] parameters)
+    public bool StartWorkerFlow(CommandMode commandMode, string workloadName, int concurrency, long totalRequestCount, int workerLimit, KeyValuePair<string, string?>[] parameters)
     {
         lock (EngineSync)
         {
@@ -136,7 +136,7 @@ public class DFrameControllerExecutionEngine : INotifyStateChanged
                 broadcaster = globalGroup.CreateBroadcasterTo<IWorkerReceiver>(connectionIds);
             }
 
-            broadcaster.CreateWorkloadAndSetup(executionId, createWorkloadCount, concurrency, totalRequestCount, workloadName, parameters!);
+            broadcaster.CreateWorkloadAndSetup(commandMode, executionId, createWorkloadCount, concurrency, totalRequestCount, workloadName, parameters!);
             StateChanged?.Invoke();
         }
 

--- a/src/DFrame.Controller/HubDefinitions.cs
+++ b/src/DFrame.Controller/HubDefinitions.cs
@@ -45,7 +45,7 @@ namespace DFrame
 
     public interface IWorkerReceiver
     {
-        void CreateWorkloadAndSetup(ExecutionId executionId, int createCount, int concurrency, long totalRequestCount, string workloadName, KeyValuePair<string, string>[] parameters);
+        void CreateWorkloadAndSetup(CommandMode commandMode, ExecutionId executionId, int createCount, int concurrency, long totalRequestCount, string workloadName, KeyValuePair<string, string>[] parameters);
         void Execute(long[] executeCount); // exec count per workload
         void Stop();
         void Teardown();
@@ -267,5 +267,13 @@ namespace DFrame
         Decimal,
         DateTime,
         String,
+    }
+
+    public enum CommandMode
+    {
+        Request,
+        Repeat,
+        Duration,
+        InfiniteLoop
     }
 }

--- a/src/DFrame.Controller/Pages/Index.razor.cs
+++ b/src/DFrame.Controller/Pages/Index.razor.cs
@@ -83,7 +83,7 @@ public partial class Index : IDisposable
 
         var totalRequest = (vm.CommandMode == CommandMode.InfiniteLoop || vm.CommandMode == CommandMode.Duration) ? long.MaxValue : vm.TotalRequest;
 
-        var okToStart = engine.StartWorkerFlow(vm.SelectedWorkload, vm.Concurrency, totalRequest, vm.RequestWorkerLimit, parameters!);
+        var okToStart = engine.StartWorkerFlow(vm.CommandMode, vm.SelectedWorkload, vm.Concurrency, totalRequest, vm.RequestWorkerLimit, parameters!);
         if (!okToStart)
         {
             logger.LogInformation("Invalid parameters, does not run workflow.");
@@ -123,7 +123,7 @@ public partial class Index : IDisposable
             {
                 if (state.TryMoveNextRepeat())
                 {
-                    var okToStart = engine.StartWorkerFlow(state.Workload, state.Concurrency, state.TotalRequest, state.WorkerLimit, state.Parameters!);
+                    var okToStart = engine.StartWorkerFlow(CommandMode.Repeat, state.Workload, state.Concurrency, state.TotalRequest, state.WorkerLimit, state.Parameters!);
                     if (okToStart)
                     {
                         return;
@@ -205,14 +205,6 @@ public class RepeatModeState
         TotalRequest += IncreaseTotalRequest;
         return true;
     }
-}
-
-public enum CommandMode
-{
-    Request,
-    Repeat,
-    Duration,
-    InfiniteLoop
 }
 
 public class IndexViewModel : IDisposable

--- a/src/DFrame.Unity/Assets/Plugins/DFrame/Runtime/DFrameWorkerApp.cs
+++ b/src/DFrame.Unity/Assets/Plugins/DFrame/Runtime/DFrameWorkerApp.cs
@@ -260,7 +260,7 @@ namespace DFrame
             logger.LogInformation($"Connect completed.");
         }
 
-        async void IWorkerReceiver.CreateWorkloadAndSetup(ExecutionId executionId, int createCount, int concurrency, long totalRequestCount, string workloadName, KeyValuePair<string, string>[] parameters)
+        async void IWorkerReceiver.CreateWorkloadAndSetup(CommandMode commandMode, ExecutionId executionId, int createCount, int concurrency, long totalRequestCount, string workloadName, KeyValuePair<string, string>[] parameters)
         {
             ThreadPoolUtility.SetMinThread(createCount * options.VirtualProcess * 2);
 
@@ -277,7 +277,7 @@ namespace DFrame
                 for (int i = 0; i < createCount; i++)
                 {
                     var workload = description.Activator.Value.Invoke(serviceProvider, description.CrateArgument(parameters));
-                    var t = (new WorkloadContext(executionId, createCount, i, concurrency, totalRequestCount, workloadLifeTime!.Token), (Workload)workload);
+                    var t = (new WorkloadContext(commandMode, executionId, createCount, i, concurrency, totalRequestCount, workloadLifeTime!.Token), (Workload)workload);
                     workloads.Add(t);
                 }
 

--- a/src/DFrame.Unity/Assets/Plugins/DFrame/Runtime/WorkloadContext.cs
+++ b/src/DFrame.Unity/Assets/Plugins/DFrame/Runtime/WorkloadContext.cs
@@ -4,6 +4,7 @@ namespace DFrame
 {
     public class WorkloadContext
     {
+        public CommandMode CommandMode { get; }
         public ExecutionId ExecutionId { get; }
         public WorkloadId WorkloadId { get; }
         public int WorkloadCount { get; }
@@ -13,8 +14,9 @@ namespace DFrame
         public long TotalRequestCount { get; }
         public CancellationToken CancellationToken { get; }
 
-        public WorkloadContext(ExecutionId executionId, int count, int index, int concurrency, long totalRequestCount, CancellationToken cancellationToken)
+        public WorkloadContext(CommandMode commandMode, ExecutionId executionId, int count, int index, int concurrency, long totalRequestCount, CancellationToken cancellationToken)
         {
+            this.CommandMode = commandMode;
             this.ExecutionId = executionId;
             this.WorkloadId = WorkloadId.New();
             this.WorkloadCount = count;

--- a/src/DFrame.Worker/DFrameWorkerApp.cs
+++ b/src/DFrame.Worker/DFrameWorkerApp.cs
@@ -260,7 +260,7 @@ namespace DFrame
             logger.LogInformation($"Connect completed.");
         }
 
-        async void IWorkerReceiver.CreateWorkloadAndSetup(ExecutionId executionId, int createCount, int concurrency, long totalRequestCount, string workloadName, KeyValuePair<string, string>[] parameters)
+        async void IWorkerReceiver.CreateWorkloadAndSetup(CommandMode commandMode, ExecutionId executionId, int createCount, int concurrency, long totalRequestCount, string workloadName, KeyValuePair<string, string>[] parameters)
         {
             ThreadPoolUtility.SetMinThread(createCount * options.VirtualProcess * 2);
 
@@ -277,7 +277,7 @@ namespace DFrame
                 for (int i = 0; i < createCount; i++)
                 {
                     var workload = description.Activator.Value.Invoke(serviceProvider, description.CrateArgument(parameters));
-                    var t = (new WorkloadContext(executionId, createCount, i, concurrency, totalRequestCount, workloadLifeTime!.Token), (Workload)workload);
+                    var t = (new WorkloadContext(commandMode, executionId, createCount, i, concurrency, totalRequestCount, workloadLifeTime!.Token), (Workload)workload);
                     workloads.Add(t);
                 }
 

--- a/src/DFrame.Worker/WorkloadContext.cs
+++ b/src/DFrame.Worker/WorkloadContext.cs
@@ -4,6 +4,7 @@ namespace DFrame
 {
     public class WorkloadContext
     {
+        public CommandMode CommandMode { get; }
         public ExecutionId ExecutionId { get; }
         public WorkloadId WorkloadId { get; }
         public int WorkloadCount { get; }
@@ -13,8 +14,9 @@ namespace DFrame
         public long TotalRequestCount { get; }
         public CancellationToken CancellationToken { get; }
 
-        public WorkloadContext(ExecutionId executionId, int count, int index, int concurrency, long totalRequestCount, CancellationToken cancellationToken)
+        public WorkloadContext(CommandMode commandMode, ExecutionId executionId, int count, int index, int concurrency, long totalRequestCount, CancellationToken cancellationToken)
         {
+            this.CommandMode = commandMode;
             this.ExecutionId = executionId;
             this.WorkloadId = WorkloadId.New();
             this.WorkloadCount = count;


### PR DESCRIPTION
## TL;DR

Add CommandMode to Context.

The `TotalRequestCount` was found to be useless when `CommandMode.InfiniteLoop` was used.
It is also possible to check with `context.TotalRequestCount == long.MaxValue`, but it is more desirable to check the `CommandMode`, so this has been fixed.