### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Cysharp</Authors>
     <Company>Cysharp</Company>
@@ -20,6 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 </Project>

--- a/sandbox/ConsoleController/ConsoleController.csproj
+++ b/sandbox/ConsoleController/ConsoleController.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/ConsoleMultipleWorker/ConsoleMultipleWorker.csproj
+++ b/sandbox/ConsoleMultipleWorker/ConsoleMultipleWorker.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/ConsoleWorker/ConsoleWorker.csproj
+++ b/sandbox/ConsoleWorker/ConsoleWorker.csproj
@@ -5,7 +5,6 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/sandbox/MinimalEcho/MinimalEcho.csproj
+++ b/sandbox/MinimalEcho/MinimalEcho.csproj
@@ -4,7 +4,6 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/sandbox/MinimalMagicOnion/MinimalMagicOnion.csproj
+++ b/sandbox/MinimalMagicOnion/MinimalMagicOnion.csproj
@@ -3,16 +3,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ZLogger" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="ZLogger" Version="1.6.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
     <PackageReference Include="MagicOnion" Version="7.0.2" />
   </ItemGroup>
 </Project>

--- a/sandbox/MinimumGrpc/MinimumGrpc.csproj
+++ b/sandbox/MinimumGrpc/MinimumGrpc.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/RestClient/RestClient.csproj
+++ b/sandbox/RestClient/RestClient.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/RunBoth/RunBoth.csproj
+++ b/sandbox/RunBoth/RunBoth.csproj
@@ -5,7 +5,6 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/DFrame.Controller/DFrame.Controller.csproj
+++ b/src/DFrame.Controller/DFrame.Controller.csproj
@@ -14,10 +14,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-	</ItemGroup>
-	
-	<ItemGroup>
 		<PackageReference Include="MagicOnion" />
 		<PackageReference Include="MessagePipe" />
 		<PackageReference Include="ObservableCollections" />

--- a/src/DFrame.RestSdk/DFrame.RestSdk.csproj
+++ b/src/DFrame.RestSdk/DFrame.RestSdk.csproj
@@ -11,10 +11,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="MessagePack" />
 		<PackageReference Include="UnitGenerator">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/DFrame.Worker/DFrame.Worker.csproj
+++ b/src/DFrame.Worker/DFrame.Worker.csproj
@@ -13,10 +13,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Compile Include="..\DFrame.Controller\HubDefinitions.cs" Link="HubDefinitions.cs" />
 	</ItemGroup>
 

--- a/src/DFrame/DFrame.csproj
+++ b/src/DFrame/DFrame.csproj
@@ -12,10 +12,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\DFrame.Controller\DFrame.Controller.csproj" />
 		<ProjectReference Include="..\DFrame.Worker\DFrame.Worker.csproj" />
 	</ItemGroup>

--- a/tests/DFrame.Tests/DFrame.Tests.csproj
+++ b/tests/DFrame.Tests/DFrame.Tests.csproj
@@ -5,7 +5,6 @@
         <!--<Nullable>enable</Nullable>-->
         <NoWarn>$(NoWarn);8632</NoWarn> <!-- CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
         <ImplicitUsings>enable</ImplicitUsings>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
